### PR TITLE
create docs: clarify predicate behavior on dirs (close #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ tarball content is written to that handle instead (the handle is left open).
 
 If a `predicate` function is passed, it is called on each system path that is
 encountered while recursively searching `dir` and `path` is only included in the
-tarball if `predicate(path)` is true.
+tarball if `predicate(path)` is true. If `predicate(path)` returns false for a
+directory, then the directory is excluded entirely: nothing under that directory
+will be included in the archive.
 
 ### Tar.extract
 

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -28,7 +28,9 @@ tarball content is written to that handle instead (the handle is left open).
 
 If a `predicate` function is passed, it is called on each system path that is
 encountered while recursively searching `dir` and `path` is only included in the
-tarball if `predicate(path)` is true.
+tarball if `predicate(path)` is true. If `predicate(path)` returns false for a
+directory, then the directory is excluded entirely: nothing under that directory
+will be included in the archive.
 """
 function create(predicate::Function, dir::AbstractString, tarball::AbstractString)
     create_dir_check(dir)


### PR DESCRIPTION
Clarify that if `predicate(path)` is false for a directory, nothing under that directory is included.