### PR TITLE
read_data: fix premature eof logic

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -154,12 +154,15 @@ function git_file_hash(
     # TODO: this largely duplicates the logic of read_data
     # read_data could be used directly if SHA offered an interface
     # where you write data to an IO object and it maintains a hash
+    t = round_up(size)
     while size > 0
-        r = readbytes!(tar, buf, size < sizeof(buf) ? round_up(size) : sizeof(buf))
-        r < 512 && eof(io) && error("premature end of tar file")
+        n = min(t, length(buf))
+        r = readbytes!(tar, buf, n)
+        r < n && eof(io) && error("premature end of tar file")
         v = view(buf, 1:min(r, size))
         SHA.update!(ctx, v)
         size -= length(v)
+        t -= r
     end
     @assert size == 0
     return bytes2hex(SHA.digest!(ctx))
@@ -407,10 +410,13 @@ function read_data(
     size::Integer,
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )::Nothing
+    t = round_up(size)
     while size > 0
-        r = readbytes!(tar, buf, size < sizeof(buf) ? round_up(size) : sizeof(buf))
-        r < 512 && eof(io) && error("premature end of tar file")
+        n = min(t, length(buf))
+        r = readbytes!(tar, buf, n)
+        r < n && eof(io) && error("premature end of tar file")
         size -= write(file, view(buf, 1:min(r, size)))
+        t -= r
     end
     @assert size == 0
     return

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -164,7 +164,7 @@ function git_file_hash(
         size -= length(v)
         t -= r
     end
-    @assert size == 0
+    @assert size == t == 0
     return bytes2hex(SHA.digest!(ctx))
 end
 
@@ -418,7 +418,7 @@ function read_data(
         size -= write(file, view(buf, 1:min(r, size)))
         t -= r
     end
-    @assert size == 0
+    @assert size == t == 0
     return
 end
 


### PR DESCRIPTION
Also applies to similar logic in git_file_hash. This removes the implicit assumption that the buffer size is a multiple of 512, although it probably should still be, but there's no real reason to require that, so why not make it work generally.