### PR TITLE
new API: Tar.rewrite([pred], old, [new])

### DIFF
--- a/src/create.jl
+++ b/src/create.jl
@@ -1,28 +1,45 @@
-@static if VERSION < v"1.4.0-DEV"
-    sorted_readdir(args...) = sort!(readdir(args...))
-else
-    sorted_readdir(args...) = readdir(args...)
-end
-
 function create_tarball(
     predicate::Function,
     tar::IO,
-    sys_path::String,       # path in the filesystem
-    tar_path::String = "."; # path in the tarball
+    sys_path::String;
+    buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
+)
+    write_tarball(tar, sys_path, buf=buf) do sys_path, tar_path
+        hdr = path_header(sys_path, tar_path)
+        hdr.type != :directory && return hdr, sys_path
+        paths = Dict{String,String}()
+        for name in readdir(sys_path)
+            sys_path′ = joinpath(sys_path, name)
+            predicate(sys_path′) || continue
+            paths[name] = sys_path′
+        end
+        return hdr, paths
+    end
+end
+
+function write_tarball(
+    callback::Function,
+    tar::IO,
+    sys_path::Any,
+    tar_path::String = ".";
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )
     w = 0
-    hdr = path_header(sys_path, tar_path)
+    hdr, data = callback(sys_path, tar_path)
     if hdr.type == :directory
-        for name in sorted_readdir(sys_path)
-            sys_path′ = joinpath(sys_path, name)
-            predicate(sys_path′) || continue
+        data isa Union{Nothing, AbstractDict{<:AbstractString}} ||
+            error("callback must return a dict of strings, got: $(repr(data))")
+        data !== nothing && for name in sort!(collect(keys(data)))
+            sys_path′ = data[name]
             tar_path′ = tar_path == "." ? name : "$tar_path/$name"
-            w += create_tarball(predicate, tar, sys_path′, tar_path′, buf=buf)
+            w += write_tarball(callback, tar, sys_path′, tar_path′, buf=buf)
         end
+    else
+        data isa Union{Nothing, AbstractString, IO} ||
+            error("callback must return nothing, string or IO, got: $(repr(data))")
     end
     if hdr.type != :directory || w == 0
-        w += write_tarball(tar, hdr, sys_path, buf=buf)
+        w += write_tarball(tar, hdr, data, buf=buf)
     end
     @assert w > 0
     return w
@@ -31,17 +48,14 @@ end
 function write_tarball(
     tar::IO,
     hdr::Header,
-    data::Union{Nothing, AbstractString, IO} = nothing;
+    data::Any = nothing;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )
-    # error checks
     check_header(hdr)
-    hdr.type != :file || data !== nothing ||
-        throw(ArgumentError("data required for file record: $(repr(hdr))"))
-
-    # write tarball header & data
     w = write_header(tar, hdr, buf=buf)
     if hdr.type == :file
+        data isa Union{AbstractString, IO} ||
+            throw(ArgumentError("file record requires path or IO: $(repr(hdr))"))
         w += write_data(tar, data, size=hdr.size, buf=buf)
     end
     return w

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -25,11 +25,11 @@ end
 
 function extract_tarball(
     predicate::Function,
-    tarball::Union{AbstractString, IO},
+    tar::IO,
     root::String;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )
-    read_tarball(predicate, tarball; buf=buf) do tar, hdr, parts
+    read_tarball(predicate, tar; buf=buf) do tar, hdr, parts
         # get the file system version of the path
         sys_path = reduce(joinpath, init=root, parts)
         # delete anything that's there already
@@ -63,14 +63,14 @@ end
 
 function git_tree_hash(
     predicate::Function,
-    tarball::Union{AbstractString, IO},
+    tar::IO,
     HashType::DataType,
     skip_empty::Bool;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )
     # build tree with leaves for files and symlinks
     tree = Dict{String,Any}()
-    read_tarball(predicate, tarball; buf=buf) do tar, hdr, parts
+    read_tarball(predicate, tar; buf=buf) do tar, hdr, parts
         isempty(parts) && return
         name = pop!(parts)
         node = tree
@@ -163,17 +163,6 @@ function git_file_hash(
     end
     @assert size == t == 0
     return bytes2hex(SHA.digest!(ctx))
-end
-
-function read_tarball(
-    extract::Function,
-    predicate::Function,
-    tarball::AbstractString;
-    buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
-)
-    open(tarball) do tar
-        read_tarball(extract, predicate, tar, buf=buf)
-    end
 end
 
 function read_tarball(

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -29,7 +29,7 @@ function extract_tarball(
     root::String;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )
-    read_tarball(predicate, tar; buf=buf) do tar, hdr, parts
+    read_tarball(predicate, tar; buf=buf) do hdr, parts
         # get the file system version of the path
         sys_path = reduce(joinpath, init=root, parts)
         # delete anything that's there already
@@ -70,7 +70,7 @@ function git_tree_hash(
 )
     # build tree with leaves for files and symlinks
     tree = Dict{String,Any}()
-    read_tarball(predicate, tar; buf=buf) do tar, hdr, parts
+    read_tarball(predicate, tar; buf=buf) do hdr, parts
         isempty(parts) && return
         name = pop!(parts)
         node = tree
@@ -199,7 +199,7 @@ function read_tarball(
             delete!(links, path)
         end
         before = applicable(position, tar) ? position(tar) : 0
-        callback(tar, hdr, split(path, '/', keepempty=false))
+        callback(hdr, split(path, '/', keepempty=false))
         applicable(position, tar) || continue
         advanced = position(tar) - before
         expected = round_up(hdr.size)


### PR DESCRIPTION
Implements low level `rewrite_tarball` in terms of `read_tarball` and `write_tarball` abstractions, use that to implement `Tar.rewrite` API. In order to support that, previous commits allow an arbitrary driver to generate a correctly constructed canonical tarball without necessarily coming from the filesystem. This abstraction of `write_tarball` may be externally useful (I have a use case in mind, which is what prompted this work) even if it's not an official public API. Having at least two internal users has helped with getting the abstraction right and finding bugs.