### PR TITLE
open_write(IO): always flush IO handle

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -45,7 +45,10 @@ function open_write(f::Function, file::Nothing)
     return file
 end
 function open_write(f::Function, file::IO)
-    f(file)
+    try f(file)
+    finally
+        flush(file)
+    end
     return file
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,7 +207,7 @@ if !Sys.iswindows()
     @testset "GNU extensions" begin
         # make a test GNU tarball with GNU `tar` from Tar_jll instead of Tar.create
         tarball, hash = make_test_tarball() do root
-            tarball, io = mktemp(); close(io)
+            tarball = tempname()
             tar(gtar -> run(`$gtar --format=gnu -C $root -cf $tarball .`))
             return tarball
         end
@@ -547,7 +547,7 @@ end
     if !Sys.iswindows()
         # alternate tarball made by GNU tar
         alternate, hash₂ = make_test_tarball() do root
-            tarball, io = mktemp(); close(io)
+            tarball = tempname()
             tar(gtar -> run(`$gtar -C $root -cf $tarball .`))
             return tarball
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -358,7 +358,7 @@ Sys.iswindows() && pop!(test_dir_paths)
         rm(tarball)
         # create(dir::String, tarball::IO)
         mktemp() do tarball, io
-            Tar.create(dir, tarball)
+            Tar.create(dir, io)
             close(io)
             @test read(tarball) == bytes
         end
@@ -380,7 +380,7 @@ Sys.iswindows() && pop!(test_dir_paths)
         rm(tarball)
         # create(predicate::Function, dir::String, tarball::IO)
         mktemp() do tarball, io
-            Tar.create(predicate, dir, tarball)
+            Tar.create(predicate, dir, io)
             close(io)
             @test read(tarball) == bytes
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -359,7 +359,6 @@ Sys.iswindows() && pop!(test_dir_paths)
         # create(dir::String, tarball::IO)
         mktemp() do tarball, io
             Tar.create(dir, io)
-            close(io)
             @test read(tarball) == bytes
         end
         rm(dir, recursive=true)
@@ -381,7 +380,6 @@ Sys.iswindows() && pop!(test_dir_paths)
         # create(predicate::Function, dir::String, tarball::IO)
         mktemp() do tarball, io
             Tar.create(predicate, dir, io)
-            close(io)
             @test read(tarball) == bytes
         end
         rm(dir, recursive=true)
@@ -588,8 +586,8 @@ end
         tarball = tempname()
         open(tarball, write=true) do io
             Tar.rewrite(alternate, io)
+            @test ref == read(tarball)
         end
-        @test ref == read(tarball)
         rm(tarball)
         # rewrite(old::IO, new::IO)
         tarball = tempname()
@@ -597,8 +595,8 @@ end
             open(tarball, write=true) do new
                 Tar.rewrite(old, new)
             end
+            @test ref == read(tarball)
         end
-        @test ref == read(tarball)
         rm(tarball)
     end
 
@@ -639,8 +637,8 @@ end
         tarball = tempname()
         open(tarball, write=true) do io
             Tar.rewrite(predicate, alternate, io)
+            @test ref == read(tarball)
         end
-        @test ref == read(tarball)
         rm(tarball)
         # rewrite(predicate::Function, old::IO, new::IO)
         tarball = tempname()
@@ -648,8 +646,8 @@ end
             open(tarball, write=true) do new
                 Tar.rewrite(predicate, old, new)
             end
+            @test ref == read(tarball)
         end
-        @test ref == read(tarball)
         rm(tarball)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -584,6 +584,13 @@ end
         end
         @test ref == read(tarball)
         rm(tarball)
+        # rewrite(old::String, new::IO)
+        tarball = tempname()
+        open(tarball, write=true) do io
+            Tar.rewrite(alternate, io)
+        end
+        @test ref == read(tarball)
+        rm(tarball)
         # rewrite(old::IO, new::IO)
         tarball = tempname()
         open(alternate) do old
@@ -625,6 +632,13 @@ end
         tarball = tempname()
         open(alternate) do io
             Tar.rewrite(predicate, io, tarball)
+        end
+        @test ref == read(tarball)
+        rm(tarball)
+        # rewrite(predicate::Functoin, old::String, new::IO)
+        tarball = tempname()
+        open(tarball, write=true) do io
+            Tar.rewrite(predicate, alternate, io)
         end
         @test ref == read(tarball)
         rm(tarball)


### PR DESCRIPTION
Test by no longer explicitly calling `close(io)` after using `Tar.create` to write a tarball: before this change, those tests failed (after fixing them to actually test writing to IO handles in the previous commit) whereas with this change they pass.

This PR also fixes the aforementioned `Tar.create` tests that weren't testing what they were supposed to tests, so if you make the test-only part of the final commit, the tests will actually fail, as they should (since flush is not called on the IO handle).

In the process I made some other minor improvements:

* use `tempname` instead of `mktemp` if the IO handle isn't needed
* `Tar.rewrite`: add two missing arg type combination tests