### PR TITLE
propagate global metadata & relax metadata checking

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -119,7 +119,10 @@ function list(
 )
     raw && strict &&
         error("`raw=true` and `strict=true` options are incompatible")
-    read_hdr = raw ? read_standard_header : read_header
+    read_hdr = raw ? read_standard_header :
+        let globals = Dict{String,String}()
+            (tar; buf) -> read_header(tar, globals, buf=buf)
+        end
     open_read(tarball) do tar
         iterate_headers(callback, tar, read_hdr, strict=strict)
     end


### PR DESCRIPTION
The primary functional change in this PR is that global extended POSIX headers are now propagated to following header entries as specified by the standard. Previously we didn't bother with this since we ignore most extended headers for which this makes sense (atime, charset, gid, gname, hdrcharset, mtime, uid, uname). The headers we do pay attention to—size, path, linkpath—are not ones that it usually makes sense to set in a global header since each entry will typically need it's own value of these.

However, for the ["skeleton" functionality](https://github.com/JuliaIO/Tar.jl/pull/48) I'm considering adding, it would be nice if the skeleton file was a valid tarball where all the files happen to have zero size. But in order to be able to reproduce the original tarball perfectly, we want to keep all the headers intact without setting their sizes to zero or modifying header checksums. One possible way to do that is to prefix each skeleton file with a global header specifying that all file sizes are zero. This change paves the way for supporting that and is generally a good change since it will allow proper propagation of global header values if, in the future, we decide to support and/or pay attention to more of them.

As a side effect, this relaxes what extended header metadata Tar will accept: previously it would fail it encountered a value that it didn't know how to handle—partly to guard against situations like a global header setting a size, path or linkpath values, which we would not handle properly. Now any metadata key-value pairs are accepted and unknown ones are just ignored.