### PR TITLE
Fix variable name in `git_file_hash()` error path

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -170,7 +170,7 @@ function git_file_hash(
     while size > 0
         n = min(t, length(buf))
         r = readbytes!(tar, buf, n)
-        r < n && eof(io) && error("premature end of tar file")
+        r < n && eof(tar) && throw(EOFError())
         v = view(buf, 1:min(r, size))
         SHA.update!(ctx, v)
         size -= length(v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,18 @@ end
     rm(tarball)
 end
 
+@testset "truncated tarball" begin
+    tarball, hash = make_test_tarball()
+    open(tarball, "a") do io
+        truncate(io, div(filesize(tarball),2))
+    end
+
+    @testset "tree_hash" begin
+        # Ensure that this throws 
+        @test_throws EOFError Tar.tree_hash(tarball)
+    end
+end
+
 if !Sys.iswindows()
     @testset "POSIX extended headers" begin
         # make a test POSIX tarball with GNU `tar` from Tar_jll instead of Tar.create


### PR DESCRIPTION
Also add a test case that hits this error path.