### PR TITLE
Fix padding assertion errors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Tar_jll = "9b64493d-8859-5bf3-93d7-7c32dd38186f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SimpleBufferStream = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 
 [targets]
-test = ["Pkg", "Random", "Tar_jll", "Test"]
+test = ["Pkg", "Random", "Tar_jll", "Test", "SimpleBufferStream"]


### PR DESCRIPTION
Tar formats pad their inputs with zeros to have all content aligned to
a certain block size; when extracting data, we used a `while` loop to
iterate until we had consumed all non-padded data within the stream,
when we actually needed to iterate until we had consumed all of the
zero-padded data as well.  This was only an issue when the stream
buffering lined up such that a `readbytes!()` call ends with reading all
nonzero content, but not all zero-padding.

To test this, I have added a buffer stream type that allows us to
control the number of bytes returned from a read operation, as well as
allowing it to be randomized, for some simple fuzzing.