### PR TITLE
tests: drop all non-stdlib test dependencies

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 include("setup.jl")
 
+NON_STDLIB_TESTS &&
 @testset "ChaosBufferStream" begin
     @testset "constant usage" begin
         io = BufferStream()
@@ -488,6 +489,7 @@ end
         end
     end
 
+    NON_STDLIB_TESTS &&
     @testset "inconvenient stream buffering" begin
         # We will try feeding in an adversarial length that used to cause an assertion error
         open(tarball, read=true) do io

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,15 +1,20 @@
 using Test
 using Random
 using ArgTools
-using SimpleBufferStream
-
-using Tar_jll
-if isdefined(Tar_jll, :tar)
-    const gtar = Tar_jll.tar
-end
 
 import Tar
 import Pkg.GitTools
+
+const NON_STDLIB_TESTS = Main == @__MODULE__
+
+if NON_STDLIB_TESTS
+    using SimpleBufferStream
+
+    using Tar_jll
+    if isdefined(Tar_jll, :tar)
+        const gtar = Tar_jll.tar
+    end
+end
 
 tree_hash(path::AbstractString) = bytes2hex(GitTools.tree_hash(path))
 


### PR DESCRIPTION
I don't intend to merge this, I've created it as a brach whose versions of Tar can be [included in Julia as a stdlib](https://github.com/JuliaLang/julia/pull/37763) without needing non-stdlib dependencies for testing. This is a transient solution until we're able to test stdlibs with non-stdlib test dependencies. cc @KristofferC, @staticfloat