### PR TITLE
Use `Sys.isexecutable()` on Windows to determine file mode

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -132,6 +132,11 @@ function extract_tarball(
                 src = reduce(joinpath, init=root, split(what, '/'))
                 dst = reduce(joinpath, init=root, split(path, '/'))
                 cp(src, dst)
+
+                # Our `cp()` doesn't copy ACL properties, so manually set them via `chmod()`
+                if Sys.iswindows()
+                    chmod(dst, filemode(src))
+                end
             end
         end
     end

--- a/src/header.jl
+++ b/src/header.jl
@@ -132,7 +132,13 @@ function path_header(sys_path::AbstractString, tar_path::AbstractString)
     elseif isfile(st)
         size = filesize(st)
         type = :file
-        mode = iszero(filemode(st) & 0o100) ? 0o644 : 0o755
+        # Windows can't re-use the `lstat` result, we need to ask
+        # the system whether it's executable or not via `access()`
+        if Sys.iswindows()
+            mode = Sys.isexecutable(sys_path) ? 0o755 : 0o644
+        else
+            mode = iszero(filemode(st) & 0o100) ? 0o644 : 0o755
+        end
         link = ""
     else
         error("unsupported file type: $(repr(sys_path))")


### PR DESCRIPTION
These two extra patches get things passing on Windows for me.