### PR TITLE
Windows extract: always chmod files

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -74,15 +74,17 @@ function extract_tarball(
         elseif hdr.type == :file
             read_data(tar, sys_path, size=hdr.size, buf=buf)
             # change executable bit if necessary
-            if Sys.iswindows() ⊻ !iszero(0o100 & hdr.mode)
+            tar_exec = !iszero(0o100 & hdr.mode)
+            sys_exec = Sys.isexecutable(sys_path)
+            if tar_exec != sys_exec
                 mode = filemode(sys_path)
-                if Sys.iswindows()
-                    # turn off all execute bits
-                    mode &= 0o666
-                else
+                if tar_exec
                     # copy read bits to execute bits with
                     # at least the user execute bit on
                     mode |= 0o100 | (mode & 0o444) >> 2
+                else
+                    # turn off all execute bits
+                    mode &= 0o666
                 end
                 chmod(sys_path, mode)
             end


### PR DESCRIPTION
@staticfloat has informed me that on Windows newly created files are neither reliably executable nor non-executable: it depends on the ACL of the directory in which the file is created. So this PR changes the logic for setting permissions to check that the executableness of the file in the tarball and the extracted file match and if not, then use `chmod` to make it so. This logic is the same everywhere, it just happens that on non-Windows platforms files aren't created with execute bits set (I think; if they are, we'll now handle it properly, i.e. by turning them off for non-executable files).