### PR TITLE
macOS: apparently Sys.isexecutable is not reliable

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -75,7 +75,7 @@ function extract_tarball(
             read_data(tar, sys_path, size=hdr.size, buf=buf)
             # change executable bit if necessary
             tar_exec = !iszero(0o100 & hdr.mode)
-            sys_exec = Sys.isexecutable(sys_path)
+            sys_exec = Sys.iswindows() && Sys.isexecutable(sys_path)
             if tar_exec != sys_exec
                 mode = filemode(sys_path)
                 if tar_exec

--- a/test/git_tools.jl
+++ b/test/git_tools.jl
@@ -10,11 +10,21 @@ Base.string(mode::GitMode) = string(UInt32(mode); base=8)
 Base.print(io::IO, mode::GitMode) = print(io, string(mode))
 
 function gitmode(path::AbstractString)
+    # Windows doens't deal with executable permissions in quite the same way,
+    # `stat()` gives a different answer than we actually want, so we use
+    # `isexecutable()` which uses `uv_fs_access()` internally.  On other
+    # platforms however, we just want to check via `stat()`.
+    function isexec(p)
+        @static if Sys.iswindows()
+            return Sys.isexecutable(p)
+        end
+        return !iszero(filemode(p) & 0o100)
+    end
     if islink(path)
         return mode_symlink
     elseif isdir(path)
         return mode_dir
-    elseif Sys.isexecutable(path)
+    elseif isexec(path)
         return mode_executable
     else
         return mode_normal


### PR DESCRIPTION
See https://github.com/JuliaLang/Pkg.jl/pull/2273. This is a real roller coaster. I would have naively thought that `Sys.isexeccutable` means the same thing as checking the user execute bit, but apparently not. It seems safer to assume that on non-Windows systems files we just created are never executable. This also avoids doing an unneccessary file stat on non-Windows systems.
