### PR TITLE
When extracting, don't use `filemode()` on windows

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -73,7 +73,7 @@ function extract_tarball(
             copy_symlinks || symlink(hdr.link, sys_path)
         elseif hdr.type == :file
             read_data(tar, sys_path, size=hdr.size, buf=buf)
-            mode = filemode(sys_path)
+            mode = Sys.iswindows() ? hdr.mode : filemode(sys_path)
             if 0o100 & hdr.mode == 0
                 # turn off all execute bits
                 mode &= 0o666

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -743,11 +743,11 @@ if Sys.iswindows() && Sys.which("icacls") !== nothing
         tarball, hash = make_test_tarball()
         mktempdir() do dir
             Tar.extract(tarball, dir)
-            f_path = joinpath("dir", "0-ffffffff")
+            f_path = joinpath(dir, "0-ffffffff")
             @test isfile(f_path)
             @test !Sys.isexecutable(f_path)
 
-            x_path = joinpath("dir", "0-xxxxxxxx")
+            x_path = joinpath(dir, "0-xxxxxxxx")
             @test isfile(x_path)
             @test Sys.isexecutable(x_path)
             

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -737,3 +737,23 @@ end
     # cleanup
     foreach(rm, keys(tarballs))
 end
+
+if Sys.iswindows() && Sys.which("icacls") !== nothing
+    @testset "windows permissions" begin
+        tarball, hash = make_test_tarball()
+        mktempdir() do dir
+            Tar.extract(tarball, dir)
+            f_path = joinpath("dir", "ffffffffff")
+            @test isfile(f_path)
+            @test !Sys.isexecutable(f_path)
+
+            x_path = joinpath("dir", "xxxxxxxxxx")
+            @test isfile(x_path)
+            @test Sys.isexecutable(x_path)
+            
+            f_acl = readchomp(`icacls $(f_path)`)
+            @test occursin("Everyone:(R,WA)", f_acl)
+            @test occursin("Everyone:(RX,WA)", x_acl)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -743,16 +743,17 @@ if Sys.iswindows() && Sys.which("icacls") !== nothing
         tarball, hash = make_test_tarball()
         mktempdir() do dir
             Tar.extract(tarball, dir)
-            f_path = joinpath("dir", "ffffffffff")
+            f_path = joinpath("dir", "0-ffffffff")
             @test isfile(f_path)
             @test !Sys.isexecutable(f_path)
 
-            x_path = joinpath("dir", "xxxxxxxxxx")
+            x_path = joinpath("dir", "0-xxxxxxxx")
             @test isfile(x_path)
             @test Sys.isexecutable(x_path)
             
             f_acl = readchomp(`icacls $(f_path)`)
             @test occursin("Everyone:(R,WA)", f_acl)
+            x_acl = readchomp(`icacls $(x_path)`)
             @test occursin("Everyone:(RX,WA)", x_acl)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -738,7 +738,7 @@ end
     foreach(rm, keys(tarballs))
 end
 
-if Sys.iswindows() && Sys.which("icacls") !== nothing
+if Sys.iswindows() && Sys.which("icacls") !== nothing && VERSION >= v"1.6"
     @testset "windows permissions" begin
         tarball, hash = make_test_tarball()
         mktempdir() do dir


### PR DESCRIPTION
Windows doesn't give realistic results from `filemode()`, so let's avoid using it to try and pick up `umask`-style environmental information, and just use the mode within the tarball.