### PR TITLE
Tar.extract: slight mode improvement

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -73,7 +73,7 @@ function extract_tarball(
             copy_symlinks || symlink(hdr.link, sys_path)
         elseif hdr.type == :file
             read_data(tar, sys_path, size=hdr.size, buf=buf)
-            mode = Sys.iswindows() ? hdr.mode : filemode(sys_path)
+            mode = hdr.mode & filemode(sys_path)
             if 0o100 & hdr.mode == 0
                 # turn off all execute bits
                 mode &= 0o666

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -750,7 +750,7 @@ if Sys.iswindows() && Sys.which("icacls") !== nothing && VERSION >= v"1.6"
             x_path = joinpath(dir, "0-xxxxxxxx")
             @test isfile(x_path)
             @test Sys.isexecutable(x_path)
-            
+
             f_acl = readchomp(`icacls $(f_path)`)
             @test occursin("Everyone:(R,WA)", f_acl)
             x_acl = readchomp(`icacls $(x_path)`)


### PR DESCRIPTION
The reason for using `filemode` to read the created mode was to respect the umask or equivalent mechanism for default permissions. Since the umask can only take permissions away, it is always correct to AND the default permissions with the desired permissions, since that will be more constrained than both the default and what the tarball requests.