### PR TITLE
miscellaneous fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,22 @@ copy symlinks if they cannot be created.
 list(tarball; [ strict = true ]) -> Vector{Header}
 list(callback, tarball; [ strict = true ])
 ```
-* `callback  :: Header --> Bool`
+* `callback  :: Header, [ <data> ] --> Any`
 * `tarball   :: Union{AbstractString, AbstractCmd, IO}`
 * `strict    :: Bool`
 
 List the contents of a tar archive ("tarball") located at the path `tarball`. If
 `tarball` is an IO handle, read the tar contents from that stream. Returns a
-vector of `Header` structs. See [`Header`](@ref) for details. If a `callback` is
-provided then instead of returning a vector of headers, the callback is called
-on each `Header`. This can be useful if the number of items in the tarball is
-large or if you want examine items prior to an error in the tarball.
+vector of `Header` structs. See [`Header`](@ref) for details.
+
+If a `callback` is provided then instead of returning a vector of headers, the
+callback is called on each `Header`. This can be useful if the number of items
+in the tarball is large or if you want examine items prior to an error in the
+tarball. If the `callback` function can accept a second argument of either type
+`Vector{UInt8}` or `Vector{Pair{Symbol, String}}` then it will be called with a
+representation of the raw header data either as a single byte vector or as a
+vector of pairs mapping field names to the raw data for that field (if these
+fields are concatenated together, the result is the raw data of the header).
 
 By default `list` will error if it encounters any tarball contents which the
 `extract` function would refuse to extract. With `strict=false` it will skip

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -8,6 +8,7 @@ const true_predicate = _ -> true
 const DEFAULT_BUFFER_SIZE = 2 * 1024 * 1024
 
 # TODO: add some version of this method to Base
+!hasmethod(skip, Tuple{Union{Base.Process, Base.ProcessChain}, Integer}) &&
 function Base.skip(io::Union{Base.Process, Base.ProcessChain}, n::Integer)
     n < 0 && throw(ArgumentError("cannot skip backwards when reading from a process"))
     isempty(skip_buffer) && resize!(skip_buffer, DEFAULT_BUFFER_SIZE)
@@ -98,16 +99,22 @@ end
     list(tarball; [ strict = true ]) -> Vector{Header}
     list(callback, tarball; [ strict = true ])
 
-        callback  :: Header --> Bool
+        callback  :: Header, [ <data> ] --> Any
         tarball   :: Union{AbstractString, AbstractCmd, IO}
         strict    :: Bool
 
 List the contents of a tar archive ("tarball") located at the path `tarball`. If
 `tarball` is an IO handle, read the tar contents from that stream. Returns a
-vector of `Header` structs. See [`Header`](@ref) for details. If a `callback` is
-provided then instead of returning a vector of headers, the callback is called
-on each `Header`. This can be useful if the number of items in the tarball is
-large or if you want examine items prior to an error in the tarball.
+vector of `Header` structs. See [`Header`](@ref) for details.
+
+If a `callback` is provided then instead of returning a vector of headers, the
+callback is called on each `Header`. This can be useful if the number of items
+in the tarball is large or if you want examine items prior to an error in the
+tarball. If the `callback` function can accept a second argument of either type
+`Vector{UInt8}` or `Vector{Pair{Symbol, String}}` then it will be called with a
+representation of the raw header data either as a single byte vector or as a
+vector of pairs mapping field names to the raw data for that field (if these
+fields are concatenated together, the result is the raw data of the header).
 
 By default `list` will error if it encounters any tarball contents which the
 `extract` function would refuse to extract. With `strict=false` it will skip

--- a/src/create.jl
+++ b/src/create.jl
@@ -64,7 +64,7 @@ function rewrite_tarball(
         else
             hdr, pos = node
             mode = hdr.type == :file && iszero(hdr.mode & 0o100) ? 0o644 : 0o755
-            hdr′ = Header(tar_path, hdr.type, mode, hdr.size, hdr.link)
+            hdr′ = Header(hdr; path=tar_path, mode=mode)
             data = hdr.type == :directory ? nothing : (old_tar, pos)
             return hdr′, data
         end
@@ -158,7 +158,7 @@ function write_header(
         w += write_extended_header(tar, extended, buf=buf)
     end
     # emit standard header
-    std_hdr = Header(hdr.path, hdr.type, hdr.mode, hdr.size, link)
+    std_hdr = Header(hdr; link=link)
     w += write_standard_header(tar, std_hdr, name=name, prefix=prefix, buf=buf)
 end
 

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -15,7 +15,7 @@ function iterate_headers(
 )
     eof(tar) && return
     hdr = read_standard_header(tar, buf=buf)
-    hdr == nothing && return
+    hdr === nothing && return
     if !raw
         globals = Dict{String,String}()
     end
@@ -421,7 +421,7 @@ function read_header(
     path = get(metadata, "path", hdr.path)
     link = get(metadata, "linkpath", hdr.link)
     # construct and return Header object
-    return Header(path, hdr.type, hdr.mode, size, link)
+    return Header(hdr; path=path, size=size, link=link)
 end
 
 using Base.Checked: mul_with_overflow, add_with_overflow

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -408,7 +408,7 @@ function read_header(
             break # non-extension header block
         end
         hdr = read_standard_header(io, buf=buf, tee=tee)
-        hdr === nothing && error("premature end of tar file")
+        hdr === nothing && throw(EOFError())
     end
     # determine final values for size, path & link
     size = hdr.size
@@ -592,7 +592,7 @@ function read_data(
         max_read_len = min(padded_size, length(buf))
         read_len = readbytes!(tar, buf, max_read_len)
         write(tee, view(buf, 1:read_len))
-        read_len < max_read_len && eof(tar) && error("premature end of tar file")
+        read_len < max_read_len && eof(tar) && throw(EOFError())
         size -= write(file, view(buf, 1:min(read_len, size)))
         padded_size -= read_len
     end
@@ -624,6 +624,6 @@ function read_data(
     length(buf) < n && resize!(buf, nextpow(2, n))
     r = readbytes!(tar, buf, n)
     write(tee, view(buf, 1:r))
-    r < n && error("premature end of tar file")
+    r < n && throw(EOFError())
     return view(buf, 1:size)
 end

--- a/src/header.jl
+++ b/src/header.jl
@@ -30,6 +30,17 @@ struct Header
     link::String
 end
 
+function Header(
+    hdr::Header;
+    path::AbstractString = hdr.path,
+    type::Symbol         = hdr.type,
+    mode::Integer        = hdr.mode,
+    size::Integer        = hdr.size,
+    link::AbstractString = hdr.link,
+)
+    Header(path, type, mode, size, link)
+end
+
 function Base.show(io::IO, hdr::Header)
     show(io, Header)
     print(io, "(")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,7 +146,7 @@ end
 @testset "truncated tarball" begin
     tarball, hash = make_test_tarball()
     open(tarball, "a") do io
-        truncate(io, div(filesize(tarball),2))
+        truncate(io, filesize(tarball) ÷ 2)
     end
 
     @testset "tree_hash" begin


### PR DESCRIPTION
- Allowing the `Tar.list` callback to receive the raw header data (especially in the form of a vector of fields) is highly useful for analyzing wild tarballs. I implemented this when working on adding [support for hard links](https://github.com/JuliaIO/Tar.jl/issues/101) so that I could look at a tarball containing hard links more easily.

- Adding a `Header` method that takes an existing `Header` object and modifies some of its fields is a pattern that's used in various places in the code base which this method makes cleaner and clearer.

- This makes all cases where the end of a tarball is encountered before it is expected throw the same `EOFError` whereas previously some places threw that error while others threw a generic error with a premature end of file message.

- This changes also makes the definition of a `skip` method for processes conditional so that when testing with a Julia version that has `Tar` as a stdlib (and thus already has this method defined), we don't break precompilation by redefining that method.