### PR TITLE
tests: better tests for tarball truncation

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -15,6 +15,7 @@ function Base.skip(io::Union{Base.Process, Base.ProcessChain}, n::Integer)
     while n > 0
         n -= readbytes!(io, skip_buffer, min(n, length(skip_buffer)))
     end
+    # TODO: our skip data should throw if there's not enough data
     return io
 end
 const skip_buffer = UInt8[]

--- a/src/create.jl
+++ b/src/create.jl
@@ -287,7 +287,7 @@ function write_data(
     while size > 0
         b = min(size, length(buf))
         n = readbytes!(data, buf, b)
-        n < b && eof(data) && error("data file too small: $data")
+        n < b && eof(data) && throw(EOFError())
         w += write(tar, view(buf, 1:n))
         size -= n
         t -= n

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -17,6 +17,10 @@ if NON_STDLIB_TESTS
     end
 end
 
+macro test_throws_broken(E, expr)
+    :(@test_broken try $(esc(expr)) catch err err end isa $(esc(E)))
+end
+
 tree_hash(path::AbstractString) = bytes2hex(GitTools.tree_hash(path))
 
 function gen_file(file::String, size::Int)


### PR DESCRIPTION
While implementing support for hardlinks, the truncated tarball test was causing problems because it was simply cutting the test tarball in half, which is neither guaranteed to create an ill-formed truncated tarball at all (it is easily possible for half a tarball to be a valid tarball by itself), nor guaranteed to consistently truncate the tarball in the same way on different platforms since we generate somewhat different test tarballs on different platforms (depending on: whether we are able to create hardlinks and what the max file name length is). The fact that this test worked previously was essentially dumb luck.

This change replaces the previous test with systematic tests that various specific truncations of a simple, consistent tarball trigger EOFErrors as expected in all the API functions that consume tarballs. It turns out that several of these functions do not error as expected in all circumstances.
