### PR TITLE
Add set_permissions argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,12 @@ recreated. The `skeleton` and `predicate` arguments cannot be used together.
 ### Tar.extract
 
 ```jl
-extract([ predicate, ] tarball, [ dir ];
-        [ skeleton, ] [ copy_symlinks ]) -> dir
+extract(
+    [ predicate, ] tarball, [ dir ];
+    [ skeleton = <none>, ]
+    [ copy_symlinks = <auto>, ]
+    [ set_permissions = true, ]
+) -> dir
 ```
 * `predicate       :: Header --> Bool`
 * `tarball         :: Union{AbstractString, AbstractCmd, IO}`

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ recreated. The `skeleton` and `predicate` arguments cannot be used together.
 extract([ predicate, ] tarball, [ dir ];
         [ skeleton, ] [ copy_symlinks ]) -> dir
 ```
-* `predicate     :: Header --> Bool`
-* `tarball       :: Union{AbstractString, AbstractCmd, IO}`
-* `dir           :: AbstractString`
-* `skeleton      :: Union{AbstractString, AbstractCmd, IO}`
-* `copy_symlinks :: Bool`
+* `predicate       :: Header --> Bool`
+* `tarball         :: Union{AbstractString, AbstractCmd, IO}`
+* `dir             :: AbstractString`
+* `skeleton        :: Union{AbstractString, AbstractCmd, IO}`
+* `copy_symlinks   :: Bool`
+* `set_permissions :: Bool`
 
 Extract a tar archive ("tarball") located at the path `tarball` into the
 directory `dir`. If `tarball` is an IO object instead of a path, then the
@@ -104,6 +105,8 @@ link to `/etc/passwd` will not be copied. Symlinks which are in any way cyclic
 will also not be copied and will instead be skipped. By default, `extract` will
 detect whether symlinks can be created in `dir` or not and will automatically
 copy symlinks if they cannot be created.
+
+If `set_permissions` is `false`, no permissions are set on the extracted files.
 
 ### Tar.list
 

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -253,7 +253,7 @@ function extract(
         true_predicate, tarball, dir,
         skeleton = skeleton,
         copy_symlinks = copy_symlinks,
-        set_permissions = set_permissions
+        set_permissions = set_permissions,
     )
 end
 

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -214,7 +214,7 @@ function extract(
     dir::Union{AbstractString, Nothing} = nothing;
     skeleton::Union{ArgWrite, Nothing} = nothing,
     copy_symlinks::Union{Bool, Nothing} = nothing,
-    same_permissions::Bool = true,
+    set_permissions::Bool = true,
 )
     predicate === true_predicate || skeleton === nothing ||
         error("extract: predicate and skeleton cannot be used together")
@@ -231,7 +231,7 @@ function extract(
                     predicate, tar, dir,
                     skeleton = skeleton,
                     copy_symlinks = copy_symlinks,
-                    same_permissions = same_permissions,
+                    set_permissions = set_permissions,
                 )
             end
         end
@@ -243,13 +243,13 @@ function extract(
     dir::Union{AbstractString, Nothing} = nothing;
     skeleton::Union{ArgWrite, Nothing} = nothing,
     copy_symlinks::Union{Bool, Nothing} = nothing,
-    same_permissions::Bool = true,
+    set_permissions::Bool = true,
 )
     extract(
         true_predicate, tarball, dir,
         skeleton = skeleton,
         copy_symlinks = copy_symlinks,
-        same_permissions = same_permissions
+        set_permissions = set_permissions
     )
 end
 

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -214,6 +214,7 @@ function extract(
     dir::Union{AbstractString, Nothing} = nothing;
     skeleton::Union{ArgWrite, Nothing} = nothing,
     copy_symlinks::Union{Bool, Nothing} = nothing,
+    same_permissions::Bool = true,
 )
     predicate === true_predicate || skeleton === nothing ||
         error("extract: predicate and skeleton cannot be used together")
@@ -230,6 +231,7 @@ function extract(
                     predicate, tar, dir,
                     skeleton = skeleton,
                     copy_symlinks = copy_symlinks,
+                    same_permissions = same_permissions,
                 )
             end
         end
@@ -241,11 +243,13 @@ function extract(
     dir::Union{AbstractString, Nothing} = nothing;
     skeleton::Union{ArgWrite, Nothing} = nothing,
     copy_symlinks::Union{Bool, Nothing} = nothing,
+    same_permissions::Bool = true,
 )
     extract(
         true_predicate, tarball, dir,
         skeleton = skeleton,
         copy_symlinks = copy_symlinks,
+        same_permissions = same_permissions
     )
 end
 

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -167,13 +167,15 @@ end
 
 """
     extract([ predicate, ] tarball, [ dir ];
-            [ skeleton, ] [ copy_symlinks ]) -> dir
+            [ skeleton, ] [ copy_symlinks ],
+            [ set_permissions ]) -> dir
 
-        predicate     :: Header --> Bool
-        tarball       :: Union{AbstractString, AbstractCmd, IO}
-        dir           :: AbstractString
-        skeleton      :: Union{AbstractString, AbstractCmd, IO}
-        copy_symlinks :: Bool
+        predicate       :: Header --> Bool
+        tarball         :: Union{AbstractString, AbstractCmd, IO}
+        dir             :: AbstractString
+        skeleton        :: Union{AbstractString, AbstractCmd, IO}
+        copy_symlinks   :: Bool
+        set_permissions :: Bool
 
 Extract a tar archive ("tarball") located at the path `tarball` into the
 directory `dir`. If `tarball` is an IO object instead of a path, then the
@@ -207,6 +209,8 @@ link to `/etc/passwd` will not be copied. Symlinks which are in any way cyclic
 will also not be copied and will instead be skipped. By default, `extract` will
 detect whether symlinks can be created in `dir` or not and will automatically
 copy symlinks if they cannot be created.
+
+If `set_permissions` is `false`, no permissions are set on the extracted files.
 """
 function extract(
     predicate::Function,

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -166,9 +166,12 @@ function list(
 end
 
 """
-    extract([ predicate, ] tarball, [ dir ];
-            [ skeleton, ] [ copy_symlinks ],
-            [ set_permissions ]) -> dir
+    extract(
+        [ predicate, ] tarball, [ dir ];
+        [ skeleton = <none>, ]
+        [ copy_symlinks = <auto>, ]
+        [ set_permissions = true, ]
+    ) -> dir
 
         predicate       :: Header --> Bool
         tarball         :: Union{AbstractString, AbstractCmd, IO}

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -53,7 +53,7 @@ function extract_tarball(
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
     skeleton::IO = devnull,
     copy_symlinks::Bool = false,
-    same_permissions::Bool = true,
+    set_permissions::Bool = true,
 )
     paths = read_tarball(predicate, tar; buf=buf, skeleton=skeleton) do hdr, parts
         # get the file system version of the path
@@ -83,7 +83,7 @@ function extract_tarball(
             error("unsupported tarball entry type: $(hdr.type)")
         end
         # apply tarball permissions
-        if same_permissions && hdr.type in (:file, :hardlink)
+        if set_permissions && hdr.type in (:file, :hardlink)
             exec = 0o100 & hdr.mode != 0
             tar_mode = exec ? 0o755 : 0o644
             sys_mode = filemode(sys_path)
@@ -140,7 +140,7 @@ function extract_tarball(
                 src = reduce(joinpath, init=root, split(what, '/'))
                 dst = reduce(joinpath, init=root, split(path, '/'))
                 cp(src, dst)
-                if same_permissions && Sys.iswindows()
+                if set_permissions && Sys.iswindows()
                     # our `cp` doesn't copy ACL properties, so manually set them via `chmod`
                     function copy_mode(src::String, dst::String)
                         chmod(dst, filemode(src))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -861,5 +861,14 @@ if Sys.iswindows() && Sys.which("icacls") !== nothing && VERSION >= v"1.6"
             x_acl = readchomp(`icacls $(x_path)`)
             @test occursin("Everyone:(RX,WA)", x_acl)
         end
+
+        mktempdir() do dir
+            Tar.extract(tarball, dir, set_permissions=false)
+            f_path = joinpath(dir, "0-ffffffff")
+            @test isfile(f_path)
+
+            x_path = joinpath(dir, "0-xxxxxxxx")
+            @test isfile(x_path)
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -584,6 +584,7 @@ end
         @arg_test tar @test_throws ErrorException tar_count(tar, strict=true)
         @arg_test tar @test n + 1 == tar_count(tar, strict=false)
     end
+    rm(tarball)
 end
 
 @testset "API: extract" begin
@@ -703,6 +704,23 @@ end
                 rm(dir, recursive=true)
             end
         end
+    end
+    rm(tarball)
+
+    @testset "set_permissions" begin
+        tarball, _ = make_test_tarball()
+        dir = Tar.extract(tarball, set_permissions=false)
+        f_path = joinpath(dir, "0-ffffffff")
+        x_path = joinpath(dir, "0-xxxxxxxx")
+        @test isfile(f_path)
+        @test isfile(x_path)
+        if !Sys.iswindows()
+            @test !Sys.isexecutable(f_path)
+            @test !Sys.isexecutable(x_path)
+        end
+        @test Sys.isexecutable(f_path) == Sys.isexecutable(x_path)
+        rm(dir, recursive=true)
+        rm(tarball)
     end
 end
 
@@ -845,7 +863,7 @@ end
 
 if Sys.iswindows() && Sys.which("icacls") !== nothing && VERSION >= v"1.6"
     @testset "windows permissions" begin
-        tarball, hash = make_test_tarball()
+        tarball, _ = make_test_tarball()
         mktempdir() do dir
             Tar.extract(tarball, dir)
             f_path = joinpath(dir, "0-ffffffff")
@@ -861,18 +879,6 @@ if Sys.iswindows() && Sys.which("icacls") !== nothing && VERSION >= v"1.6"
             x_acl = readchomp(`icacls $(x_path)`)
             @test occursin("Everyone:(RX,WA)", x_acl)
         end
-
-        mktempdir() do dir
-            Tar.extract(tarball, dir, set_permissions=false)
-            f_path = joinpath(dir, "0-ffffffff")
-            @test isfile(f_path)
-            !Sys.iswindows() && @test !isexecutable(f_path)
-
-            x_path = joinpath(dir, "0-xxxxxxxx")
-            @test isfile(x_path)
-            !Sys.iswindows() && @test !isexecutable(x_path)
-
-            @test isexecutable(f_path) == isexecutable(x_path)
-        end
+        rm(tarball)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -866,9 +866,13 @@ if Sys.iswindows() && Sys.which("icacls") !== nothing && VERSION >= v"1.6"
             Tar.extract(tarball, dir, set_permissions=false)
             f_path = joinpath(dir, "0-ffffffff")
             @test isfile(f_path)
+            !Sys.iswindows() && @test !isexecutable(f_path)
 
             x_path = joinpath(dir, "0-xxxxxxxx")
             @test isfile(x_path)
+            !Sys.iswindows() && @test !isexecutable(x_path)
+
+            @test isexecutable(f_path) == isexecutable(x_path)
         end
     end
 end


### PR DESCRIPTION
This adds an option to extract a tarball without using any of the file permissions in the tarball.

I primarily need this on Windows so that I can extract a tarball and have all the extracted files just inherit permissions from the folder where I extract them to.

If this PR is acceptable I'll add a test and docs.