### PR TITLE
read_standard_header: always keep reading to the end

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -552,11 +552,9 @@ function read_standard_header(
 )
     header_view = read_data(io, size=512, buf=buf, tee=tee)
     if all(iszero, header_view)
-        if tee !== devnull
-            while !eof(io)
-                r = readbytes!(io, buf)
-                write(tee, view(buf, 1:r))
-            end
+        while !eof(io)
+            r = readbytes!(io, buf)
+            write(tee, view(buf, 1:r))
         end
         return nothing
     end


### PR DESCRIPTION
If we don't do this then reading a tarball from a process and ending early will cause a `SIGPIPE`, which we don't want to do, and which we recently made an error (again) on Julia master.
