### PR TITLE
read to the end of tarballs

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -552,11 +552,9 @@ function read_standard_header(
 )
     header_view = read_data(io, size=512, buf=buf, tee=tee)
     if all(iszero, header_view)
-        if tee !== devnull
-            while !eof(io)
-                r = readbytes!(io, buf)
-                write(tee, view(buf, 1:r))
-            end
+        while !eof(io)
+            r = readbytes!(io, buf)
+            write(tee, view(buf, 1:r))
         end
         return nothing
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -618,6 +618,7 @@ end
                 file = tempname()
                 touch(file)
                 @test_throws ErrorException Tar.extract(tar, file)
+                read(tar) # consume the rest
                 rm(file)
             end
             # extract(tarball, dir) — non-empty directory (error)
@@ -625,6 +626,7 @@ end
                 dir = mktempdir()
                 touch(joinpath(dir, "file"))
                 @test_throws ErrorException Tar.extract(tar, dir)
+                read(tar) # consume the rest
                 rm(dir, recursive=true)
             end
         end
@@ -693,6 +695,7 @@ end
                 file = tempname()
                 touch(file)
                 @test_throws ErrorException Tar.extract(predicate, tar, file)
+                read(tar) # consume the rest
                 rm(file)
             end
             # extract(predicate, tarball, dir) — non-empty directory (error)
@@ -700,6 +703,7 @@ end
                 dir = mktempdir()
                 touch(joinpath(dir, "file"))
                 @test_throws ErrorException Tar.extract(predicate, tar, dir)
+                read(tar) # consume the rest
                 rm(dir, recursive=true)
             end
         end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -130,7 +130,9 @@ function make_test_dir(gen_skip::Bool=false)
     fpath = joinpath(dir, "dir", "file")
     touch(fpath)
     open(fpath, write=true) do io
-        write(io, rand(UInt8, 1000))
+        for i = 1:1000
+            write(io, i % UInt8)
+        end
     end
     mkdir(joinpath(dir, "empty"))
     if gen_skip


### PR DESCRIPTION
This includes two changes to fix https://github.com/JuliaIO/ArgTools.jl/issues/20:

- `Tar.list` now reads to the end of the tarball instead of stopping reading when it hits a zero block
- test sets that expect errors now explicitly read to the end of the tarball inside of the `@arg_test` block

There's also an unrelated change to `make_test_dir` that bit me while making this change.