### PR TITLE
Fix ~160 invalidations from partially-inferred kwargs to `Header`

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -339,7 +339,7 @@ function read_tarball(
 )
     write_skeleton_header(skeleton, buf=buf)
     # symbols for path types except symlinks store the link
-    paths = Dict{String,Any}()
+    paths = Dict{String,Union{String,Symbol,Int64}}()
     globals = Dict{String,String}()
     while !eof(tar)
         hdr = read_header(tar, globals=globals, buf=buf, tee=skeleton)
@@ -358,7 +358,7 @@ function read_tarball(
                 Refusing to extract — possible attack!
                 """
             end
-            path = isempty(path) ? part : "$path/$part"
+            path = isempty(path) ? String(part) : "$path/$part"
         end
         hdr′ = Header(hdr, path=path)
         # check that hardlinks refer to already-seen files

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -339,7 +339,7 @@ function read_tarball(
 )
     write_skeleton_header(skeleton, buf=buf)
     # symbols for path types except symlinks store the link
-    paths = Dict{String,Union{String,Symbol,Int64}}()
+    paths = Dict{String,Any}()
     globals = Dict{String,String}()
     while !eof(tar)
         hdr = read_header(tar, globals=globals, buf=buf, tee=skeleton)
@@ -371,7 +371,7 @@ function read_tarball(
             hdr = Header(hdr, link=link)
             hdr′ = Header(hdr′, link=link)
             what = get(paths, link, Symbol("non-existent"))
-            if what isa Integer # plain file
+            if what isa Int64 # plain file
                 hdr′ = Header(hdr′, size=what)
             else
                 err = """


### PR DESCRIPTION
These get invalidated by loading Static.jl, specifically the method
```
Base.convert(::Type{T}, ::StaticInt{N}) where {T<:Number,N} = convert(T, N)
```

CC @ChrisRackauckas