### PR TITLE
[doc] add documentation index file

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,10 @@
+# Tar
+
+```@docs
+Tar.create
+Tar.extract
+Tar.list
+Tar.rewrite
+Tar.tree_hash
+Tar.Header
+```


### PR DESCRIPTION
fix #81 

Should we split out the [API usage section](https://github.com/JuliaIO/Tar.jl#api--usage) in the README and put it in the docs?

Then leave a link to the docs in the README.

It seems that the introduction of the functions are directly copied from the docstring.

Then we just need to move the "Compression" and "API comparison" sections to docs.
We can also move "Design & Features" to docs if necessary.

