### PR TITLE
Improve inference for Symbol operations

### DIFF
--- a/src/create.jl
+++ b/src/create.jl
@@ -89,7 +89,7 @@ function write_tarball(
     tar_path::String = ".";
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )
-    hdr, data = callback(sys_path, tar_path)
+    hdr, data = callback(sys_path, tar_path)::Tuple{Header,Any}
     if hdr.type == :directory
         data isa Union{Nothing, AbstractDict{<:AbstractString}} ||
             error("callback must return a dict of strings, got: $(repr(data))")

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -190,7 +190,7 @@ function link_target(
     isempty(path_parts) && return
     target = join(path_parts, '/')
     # if link ends in `/` or `.` target must be a directory
-    part in ("", ".") && paths[target] != :directory && return
+    part in ("", ".") && paths[target] !== :directory && return
     # can't copy a circular link to a prefix of itself
     (path == target || startswith(path, "$target/")) && return
     return target


### PR DESCRIPTION
This fixes some invalidations when loading Static.jl, which defines
a new `==` operator for `StaticSymbol`.