### PR TITLE
Standardize string types in match call

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -587,7 +587,7 @@ function read_standard_header(
         check_checksum_field(buf)
     catch err
         if err isa ErrorException
-            msg = match(r"^(.*?)\s*\[header block data\]"s, err.msg).captures[1]
+            msg = match(r"^(.*?)\s*\[header block data\]"s, convert(Union{String, SubString{String}}, err.msg)::Union{String, SubString{String}}).captures[1]
             msg = "This does not appear to be a TAR file/stream — $msg. Note: Tar.jl does not handle decompression; if the tarball is compressed you must use an external command like `gzcat` or package like CodecZlib.jl to decompress it. See the README file for examples."
             err = ErrorException(msg)
         end


### PR DESCRIPTION
This will probably fail without the new `convert` methods in https://github.com/JuliaLang/julia/pull/44500, so wait until that is merged and we're ready to commit to Julia 1.9.