### PR TITLE
[WIP] Add the `unsupported_file_type::Symbol` kwarg to the `Tar.create_tarball` function

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -7,6 +7,8 @@ const true_predicate = _ -> true
 # 2 MiB to take advantage of THP if enabled
 const DEFAULT_BUFFER_SIZE = 2 * 1024 * 1024
 
+include("types.jl")
+
 # TODO: add some version of this method to Base
 !hasmethod(skip, Tuple{Union{Base.Process, Base.ProcessChain}, Integer}) &&
 function Base.skip(io::Union{Base.Process, Base.ProcessChain}, n::Integer)
@@ -460,5 +462,7 @@ check_tree_hash_tarball(tarball::AbstractString) =
     """)
 
 check_tree_hash_tarball(tarball::ArgRead) = nothing
+
+include("options.jl")
 
 end # module

--- a/src/create.jl
+++ b/src/create.jl
@@ -3,8 +3,10 @@ function create_tarball(
     tar::IO,
     root::String;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
+    kwargs...
 )
-    write_tarball(tar, root, buf=buf) do sys_path, tar_path
+    options = Options(; kwargs...)
+    write_tarball(tar, root, options, buf=buf) do sys_path, tar_path
         hdr = path_header(sys_path, tar_path)
         hdr.type != :directory && return hdr, sys_path
         paths = Dict{String,String}()
@@ -86,6 +88,7 @@ function write_tarball(
     callback::Function,
     tar::IO,
     sys_path::Any,
+    options,
     tar_path::String = ".";
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )

--- a/src/header.jl
+++ b/src/header.jl
@@ -134,7 +134,7 @@ function check_header(hdr::Header)
     error(msg)
 end
 
-function path_header(sys_path::AbstractString, tar_path::AbstractString)
+function path_header(sys_path::AbstractString, tar_path::AbstractString, options)
     st = lstat(sys_path)
     if islink(st)
         size = 0
@@ -158,7 +158,7 @@ function path_header(sys_path::AbstractString, tar_path::AbstractString)
         end
         link = ""
     else
-        error("unsupported file type: $(repr(sys_path))")
+        unsupported_file_type(options, sys_path)
     end
     Header(tar_path, type, mode, size, link)
 end

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,0 +1,9 @@
+function unsupported_file_type(options::Options, sys_path)
+    msg = "unsupported file type: $(repr(sys_path))"
+    if options.unsupported_file_type == :warn
+        @warn(msg)
+    else
+        throw(ErrorException(msg))
+    end
+    return nothing
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,16 @@
+struct Options
+    unsupported_file_type::Symbol
+
+    function Options(;
+            unsupported_file_type::Symbol = :error,
+        )
+        if (unsupported_file_type !== :error) && (unsupported_file_type !== :warn)
+            msg = "unsupported_file_type must be either :error or :warn"
+            throw(ArgumentError(msg))
+        end
+        options = new(
+            unsupported_file_type,
+        )
+        return options
+    end
+end


### PR DESCRIPTION
This pull request adds the `unsupported_file_type::Symbol` kwarg to the `Tar.create_tarball` function.

The possible values of `unsupported_file_type` are:
1. `:error` (default)
2. `:warn`