### PR TITLE
fix invalidations from Static.jl

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -383,7 +383,7 @@ function read_tarball(
             end
         end
         # check if we should extract or skip
-        if !predicate(hdr′) # pass normalized header
+        if !(predicate(hdr′)::Bool) # pass normalized header
             skip_data(tar, hdr.size)
             continue
         end


### PR DESCRIPTION
This should hopefully fix quite some invalidations coming from Static.jl.

<details>

<summary>
Here is the code:

</summary>

```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0 (2022-08-17)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.8) pkg> activate --temp

(jl_PDrBpd) pkg> add Static
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/tmp/jl_PDrBpd/Project.toml`
  [aedffcd0] + Static v0.7.6
    Updating `/tmp/jl_PDrBpd/Manifest.toml`
  [615f187c] + IfElse v0.1.1
  [aedffcd0] + Static v0.7.6

julia> using SnoopCompileCore

julia> invalidations = @snoopr using Static

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
7-element Vector{SnoopCompile.MethodInvalidations}:
...
 inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 158: signature Tuple{typeof(!), Any} triggered MethodInstance for Tar.var"#read_tarball#47"(::Vector{UInt8}, ::Base.DevNull, ::typeof(Tar.read_tarball), ::Function, ::Function, ::Base.Process) (48 children)
```

</details>

Since

- `!predicate`  is used here in an `if` stament - and `if` statements only accept `Bool`s
- and it is documented that `predicate` has to return a `Bool`

it appears to be sane to assert that `predicate` returns a `Bool` here.
