### PR TITLE
convert output of `readbytes!` to `Int`

### DIFF
--- a/src/create.jl
+++ b/src/create.jl
@@ -291,8 +291,8 @@ function write_data(
         throw(ArgumentError("cannot write negative data: $size"))
     w, t = 0, round_up(size)
     while size > 0
-        b = min(size, length(buf))
-        n = readbytes!(data, buf, b)::Integer
+        b = Int(min(size, length(buf)))::Int
+        n = Int(readbytes!(data, buf, b))::Int
         n < b && eof(data) && throw(EOFError())
         w += write(tar, view(buf, 1:n))
         size -= n

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -296,8 +296,8 @@ function git_file_hash(
     # where you write data to an IO object and it maintains a hash
     padded_size = round_up(size)
     while padded_size > 0
-        max_read_len = Int(min(padded_size, length(buf)))
-        read_len = readbytes!(tar, buf, max_read_len)
+        max_read_len = Int(min(padded_size, length(buf)))::Int
+        read_len = Int(readbytes!(tar, buf, max_read_len))::Int
         read_len < max_read_len && eof(tar) && throw(EOFError())
         nonpadded_view = view(buf, 1:Int(min(read_len, size)))
         SHA.update!(ctx, nonpadded_view)
@@ -576,7 +576,7 @@ function read_standard_header(
     # zero block indicates end of tarball
     if all(iszero, data)
         while !eof(io)
-            r = readbytes!(io, buf)::Integer
+            r = Int(readbytes!(io, buf))::Int
             write(tee, view(buf, 1:r))
         end
         return nothing
@@ -700,8 +700,8 @@ function read_data(
 )::Nothing
     padded_size = round_up(size)
     while padded_size > 0
-        max_read_len = Int(min(padded_size, length(buf)))
-        read_len = readbytes!(tar, buf, max_read_len)::Integer
+        max_read_len = Int(min(padded_size, length(buf)))::Int
+        read_len = Int(readbytes!(tar, buf, max_read_len))::Int
         write(tee, view(buf, 1:read_len))
         read_len < max_read_len && eof(tar) && throw(EOFError())
         size -= write(file, view(buf, 1:Int(min(read_len, size))))


### PR DESCRIPTION
This improves type stability and fixes some invalidations when loading ArrayInterface.jl.
It follows the approach of #112 to cast the optional argument of `readbytes!` to an `Int` and fixes additional invalidations not covered by #138, #139.

I built Julia from the current `release-1.8` branch with
```bash
julia$ git diff release-1.8
diff --git a/stdlib/Tar.version b/stdlib/Tar.version
index b7ee00e5a2..7835dfb18f 100644
--- a/stdlib/Tar.version
+++ b/stdlib/Tar.version
@@ -1,4 +1,4 @@
-TAR_BRANCH = master
-TAR_SHA1 = 0f8a73d5cd4b0c8f1f3c36799c96e9515e9dc595
-TAR_GIT_URL := https://github.com/JuliaIO/Tar.jl.git
-TAR_TAR_URL = https://api.github.com/repos/JuliaIO/Tar.jl/tarball/$1
+TAR_BRANCH = hr/fix_invalidations
+TAR_SHA1 = f63d9034a30171962de52c375572a310e1dffd2c
+TAR_GIT_URL := https://github.com/ranocha/Tar.jl.git
+TAR_TAR_URL = https://api.github.com/repos/ranocha/Tar.jl/tarball/$1
```
Then, I get no invalidations from loading ArrayInterface.jl anymore:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("ArrayInterface")

julia> using SnoopCompileCore; invalidations = @snoopr(using ArrayInterface); using SnoopCompile

julia> trees = invalidation_trees(invalidations);

julia> import Tar; ftrees = filtermod(Tar, trees)
SnoopCompile.MethodInvalidations[]
```