### PR TITLE
Test.extract: test that extracting outside of dest directory is an error

### DIFF
--- a/test/setup.jl
+++ b/test/setup.jl
@@ -251,4 +251,16 @@ function test_error_prefix(f::Function, prefix::AbstractString)
     @test startswith(val.msg, prefix)
 end
 
+function test_extract_attack(hdrs::Tar.Header...)
+    tarball, io = mktemp()
+    for hdr in hdrs
+        Tar.write_header(io, hdr)
+    end
+    close(io)
+    @test_throws ErrorException Tar.extract(tarball)
+    @test_throws ErrorException Tar.rewrite(tarball)
+    @test_throws ErrorException Tar.tree_hash(tarball)
+    rm(tarball)
+end
+
 const test_data_dir = joinpath(@__DIR__, "data")

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -251,16 +251,33 @@ function test_error_prefix(f::Function, prefix::AbstractString)
     @test startswith(val.msg, prefix)
 end
 
-function test_extract_attack(hdrs::Tar.Header...)
+function test_extract_attack(body::Function, hdrs::Tar.Header...)
     tarball, io = mktemp()
     for hdr in hdrs
         Tar.write_header(io, hdr)
     end
     close(io)
+    body(tarball)
+    rm(tarball)
+end
+
+function test_extract_attack(hdrs::Tar.Header...)
+    test_extract_attack(hdrs...) do tarball
+        @test_throws ErrorException Tar.extract(tarball)
+        @test_throws ErrorException Tar.rewrite(tarball)
+        @test_throws ErrorException Tar.tree_hash(tarball)
+    end
+end
+
+# This is for testing tarballs containing paths that have backslashes like
+# `C:\\dir` which is a valid path component on UNIX but should error upon
+# extraction on Windows. So it tests that `Tar.extract` fails everywhere but
+# allows `Tar.rewrite` and `Tar.tree_hash` to not fail on non-Windows systems.
+function test_windows_variation(tarball)
     @test_throws ErrorException Tar.extract(tarball)
+    Sys.iswindows() && return
     @test_throws ErrorException Tar.rewrite(tarball)
     @test_throws ErrorException Tar.tree_hash(tarball)
-    rm(tarball)
 end
 
 const test_data_dir = joinpath(@__DIR__, "data")


### PR DESCRIPTION
We have always prevented this for security reasons, but although we have tested that the fancy attacks using symlinks are prevented, we haven't been testing that the basic attack of extracting a relative or absolute  path outside of the tarball is prevented. This adds tests for that. It also factors the common logic for these attack tests into a helper function and tests that `Tar.rewrite` errors in the same way.
