### PR TITLE
Check for bad Windows paths prior to extraction; allow check on creation

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -57,6 +57,7 @@ function extract_tarball(
 )
     root = normpath(root)
     paths = read_tarball(predicate, tar; buf=buf, skeleton=skeleton) do hdr, parts
+        Sys.iswindows() && check_windows_path(hdr.path, parts)
         # get the file system version of the path
         sys_path = isempty(parts) ? "." : reduce(joinpath, parts)
         isabspath(sys_path) &&

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -293,4 +293,10 @@ function test_windows_variation(tarball)
     @test_throws ErrorException Tar.tree_hash(tarball)
 end
 
+# TODO: handle properly (fail if error, pass if no error)
+# This should really be part off the Test stdlib
+macro test_no_throw(ex)
+    esc(ex)
+end
+
 const test_data_dir = joinpath(@__DIR__, "data")


### PR DESCRIPTION
Check for bad Windows paths prior to extraction; allow check on creation Previously, we didn't bat an eye at extracting paths that are considered bad or illegal on Windows. This explicitly checks for such paths before  attempting extraction on Windows. On all platforms it introduces the `portable` flag for tarball creating operations, which does the same checks and errors if you would have created a tarball that would error   upon extraction on Windows.
