### PR TITLE
extract: use open(create=true) when extracting files

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -727,7 +727,7 @@ function read_data(
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
     tee::IO = devnull,
 )::Nothing
-    open(file, write=true) do file′
+    open(file, create=true, write=true) do file′
         read_data(tar, file′, size=size, buf=buf, tee=tee)
     end
 end


### PR DESCRIPTION
Using `open`'s `create` flag when extracting files should prevent certain kinds of attacks if all our other defenses don't catch them, e.g. writing `CON` on Windows or `/etc/passwd` on UNIX. Closes #147.