### PR TITLE
minimize impact of invalidations due to uninferred `ctx`

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -395,14 +395,17 @@ function tree_hash(
     algorithm::AbstractString = "git-sha1",
     skip_empty::Bool = false,
 )
-    HashType =
-        algorithm == "git-sha1"   ? SHA.SHA1_CTX :
-        algorithm == "git-sha256" ? SHA.SHA256_CTX :
-            error("invalid tree hashing algorithm: $algorithm")
-
     check_tree_hash_tarball(tarball)
-    arg_read(tarball) do tar
-        git_tree_hash(predicate, tar, HashType, skip_empty)
+    if algorithm == "git-sha1"
+        return arg_read(tarball) do tar
+            git_tree_hash(predicate, tar, SHA.SHA1_CTX, skip_empty)
+        end
+    elseif algorithm == "git-sha256"
+        return arg_read(tarball) do tar
+            git_tree_hash(predicate, tar, SHA.SHA256_CTX, skip_empty)
+        end
+    else
+        error("invalid tree hashing algorithm: $algorithm")
     end
 end
 

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -283,17 +283,9 @@ end
 function git_object_hash(
     emit::Function,
     kind::AbstractString,
-    HashType::DataType,
-)
-    # re-dispatch over function barrier to avoid propagating invalidations due to uninferred 
-    # `ctx = HashType()`
-    git_object_hash(emit, kind, HashType()::SHA.SHA_CTX)
-end
-function git_object_hash(
-    emit::Function,
-    kind::AbstractString,
-    ctx::SHA.SHA_CTX,
-)   
+    ::Type{HashType},
+) where HashType
+    ctx = HashType()
     body = codeunits(sprint(emit))
     SHA.update!(ctx, codeunits("$kind $(length(body))\0"))
     SHA.update!(ctx, body)
@@ -303,19 +295,10 @@ end
 function git_file_hash(
     tar::IO,
     size::Integer,
-    HashType::DataType;
+    ::Type{HashType};
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
-)
-    # re-dispatch over function barrier to avoid propagating invalidations due to uninferred 
-    # `ctx = HashType()`
-    git_file_hash(tar, size, HashType()::SHA.SHA_CTX; buf=buf)
-end
-function git_file_hash(
-    tar::IO,
-    size::Integer,
-    ctx::SHA.SHA_CTX;
-    buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
-)
+) where HashType
+    ctx = HashType()
     SHA.update!(ctx, codeunits("blob $size\0"))
     # TODO: this largely duplicates the logic of read_data
     # read_data could be used directly if SHA offered an interface

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -287,12 +287,12 @@ function git_object_hash(
 )
     # re-dispatch over function barrier to avoid propagating invalidations due to uninferred 
     # `ctx = HashType()`
-    git_object_hash(emit, kind, HashType())
+    git_object_hash(emit, kind, HashType()::SHA.SHA_CTX)
 end
 function git_object_hash(
     emit::Function,
     kind::AbstractString,
-    ctx::SHA_CTX,
+    ctx::SHA.SHA_CTX,
 )   
     body = codeunits(sprint(emit))
     SHA.update!(ctx, codeunits("$kind $(length(body))\0"))
@@ -308,12 +308,12 @@ function git_file_hash(
 )
     # re-dispatch over function barrier to avoid propagating invalidations due to uninferred 
     # `ctx = HashType()`
-    git_file_hash(tar, size, HashType(); buf)
+    git_file_hash(tar, size, HashType()::SHA.SHA_CTX; buf)
 end
 function git_file_hash(
     tar::IO,
     size::Integer,
-    ctx::SHA_CTX;
+    ctx::SHA.SHA_CTX;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )
     SHA.update!(ctx, codeunits("blob $size\0"))

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -308,7 +308,7 @@ function git_file_hash(
 )
     # re-dispatch over function barrier to avoid propagating invalidations due to uninferred 
     # `ctx = HashType()`
-    git_file_hash(tar, size, HashType()::SHA.SHA_CTX; buf)
+    git_file_hash(tar, size, HashType()::SHA.SHA_CTX; buf=buf)
 end
 function git_file_hash(
     tar::IO,

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -208,10 +208,10 @@ end
 function git_tree_hash(
     predicate::Function,
     tar::IO,
-    HashType::DataType,
+    ::Type{HashType},
     skip_empty::Bool;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
-)
+) where HashType
     # build tree with leaves for files and symlinks
     tree = Dict{String,Any}()
     read_tarball(predicate, tar; buf=buf) do hdr, parts


### PR DESCRIPTION
I originally tried to fix this in SHA.jl, but it is more probably more appropriate to fix it here. The problem is summarized here: https://github.com/JuliaCrypto/SHA.jl/pull/88#issuecomment-1516151954