### PR TITLE
Give hint about possible insufficient storage on error message

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -718,9 +718,9 @@ function read_data(
         padded_size -= read_len
     end
     @assert size == padded_size == 0 """
-                                     size == padded_size == 0
-                                     This error sometimes is a symptom of insufficient storage, make sure you have enough space on disk.
-                                     """
+        size == padded_size == 0
+        This error may be a symptom of insufficient disk space on the device the tarball is being written to.
+        """
     return
 end
 

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -717,7 +717,10 @@ function read_data(
         size -= write(file, view(buf, 1:Int(min(read_len, size))))
         padded_size -= read_len
     end
-    @assert size == padded_size == 0
+    @assert size == padded_size == 0 """
+                                     size == padded_size == 0
+                                     This error sometimes is a symptom of insufficient storage, make sure you have enough space on disk.
+                                     """
     return
 end
 


### PR DESCRIPTION
I'm usually not a big fan of having overly specific hints in error messages, but basically every time I've seen
```
Error: AssertionError: size == padded_size == 0
```
reported during installation of artifacts the problem was insufficient space on disk.  I think in this case it'd be beneficial to tip to check disk usage.