### PR TITLE
Fix some issues found by JET

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -1,5 +1,6 @@
 module Tar
 
+import SHA
 using ArgTools
 
 const true_predicate = _ -> true

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -334,8 +334,9 @@ function check_skeleton_header(
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 )
     hdr = read_standard_header(skeleton, buf=buf)
-    hdr.type == :g && hdr.path == SKELETON_MAGIC ||
+    if hdr === nothing || !(hdr.type == :g && hdr.path == SKELETON_MAGIC)
         error("not a skeleton file: $skeleton")
+    end
     skip_data(skeleton, hdr.size)
 end
 

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -1,5 +1,3 @@
-import SHA
-
 function iterate_headers(
     callback::Function,
     tar::IO;
@@ -211,7 +209,7 @@ function git_tree_hash(
     ::Type{HashType},
     skip_empty::Bool;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
-) where HashType
+) where HashType <: SHA.SHA_CTX
     # build tree with leaves for files and symlinks
     tree = Dict{String,Any}()
     read_tarball(predicate, tar; buf=buf) do hdr, parts
@@ -284,7 +282,7 @@ function git_object_hash(
     emit::Function,
     kind::AbstractString,
     ::Type{HashType},
-) where HashType
+) where HashType <: SHA.SHA_CTX
     ctx = HashType()
     body = codeunits(sprint(emit))
     SHA.update!(ctx, codeunits("$kind $(length(body))\0"))
@@ -297,7 +295,7 @@ function git_file_hash(
     size::Integer,
     ::Type{HashType};
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
-) where HashType
+) where HashType <: SHA.SHA_CTX
     ctx = HashType()
     SHA.update!(ctx, codeunits("blob $size\0"))
     # TODO: this largely duplicates the logic of read_data

--- a/test/git_tools.jl
+++ b/test/git_tools.jl
@@ -36,7 +36,7 @@ end
 
 Calculate the git blob hash of a given path.
 """
-function blob_hash(::Type{HashType}, path::AbstractString) where HashType
+function blob_hash(::Type{HashType}, path::AbstractString) where HashType <: SHA.SHA_CTX
     ctx = HashType()
     if islink(path)
         datalen = length(readlink(path))
@@ -96,7 +96,7 @@ end
 
 Calculate the git tree hash of a given path.
 """
-function tree_hash(::Type{HashType}, root::AbstractString) where HashType
+function tree_hash(::Type{HashType}, root::AbstractString) where HashType <: SHA.SHA_CTX
     entries = Tuple{String, Vector{UInt8}, GitMode}[]
     for f in readdir(root)
         # Skip `.git` directories

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -947,6 +947,14 @@ end
         skeleton = tempname()
         dir = Tar.extract(tarball, skeleton=skeleton)
         @test isfile(skeleton)
+        # test that an empty tarball fails
+        truncated = tempname()
+        write(truncated, zeros(1024))
+        arg_readers(truncated) do skel
+            @arg_test skel begin
+                @test_throws ErrorException Tar.create(dir, skeleton=skel)
+            end
+        end
         # test skeleton listing
         hdrs = Tar.list(tarball)
         arg_readers(skeleton) do skel


### PR DESCRIPTION
With these changes if you run JET on Julia master, Tar passes:
```jl
julia> import JET; JET.report_package("Tar")
[toplevel-info] virtualized the context of Main (took 0.006 sec)
[toplevel-info] entered into /Users/stefan/dev/Tar/src/Tar.jl
[toplevel-info] entered into /Users/stefan/dev/Tar/src/header.jl
[toplevel-info]  exited from /Users/stefan/dev/Tar/src/header.jl (took 0.022 sec)
[toplevel-info] entered into /Users/stefan/dev/Tar/src/create.jl
[toplevel-info]  exited from /Users/stefan/dev/Tar/src/create.jl (took 0.043 sec)
[toplevel-info] entered into /Users/stefan/dev/Tar/src/extract.jl
[toplevel-info]  exited from /Users/stefan/dev/Tar/src/extract.jl (took 0.069 sec)
[toplevel-info]  exited from /Users/stefan/dev/Tar/src/Tar.jl (took 0.196 sec)
[toplevel-info] analyzing from top-level definitions (201/201)
[toplevel-info] analyzed 201 top-level definitions (took 0.26 sec)
No errors detected
```