### PR TITLE
Add skip_symlink keyword to tree_hash

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -342,6 +342,7 @@ end
         tarball    :: Union{AbstractString, AbstractCmd, IO}
         algorithm  :: AbstractString
         skip_empty :: Bool
+        skip_symlink :: Bool
 
 Compute a tree hash value for the file tree that the tarball contains. By
 default, this uses git's tree hashing algorithm with the SHA1 secure hash
@@ -389,21 +390,24 @@ hash, the hash value that you get will match the hash value computed by
 are hashing trees that may contain empty directories (i.e. do not come from a
 git repo), however, it is recommended that you hash them using a tool (such as
 this one) that does not ignore empty directories.
+
+The `skip_symlink` will skip symlinks in the tarfile.
 """
 function tree_hash(
     predicate::Function,
     tarball::ArgRead;
     algorithm::AbstractString = "git-sha1",
     skip_empty::Bool = false,
+    skip_symlink::Bool = false,
 )
     check_tree_hash_tarball(tarball)
     if algorithm == "git-sha1"
         return arg_read(tarball) do tar
-            git_tree_hash(predicate, tar, SHA.SHA1_CTX, skip_empty)
+            git_tree_hash(predicate, tar, SHA.SHA1_CTX, skip_empty, skip_symlink)
         end
     elseif algorithm == "git-sha256"
         return arg_read(tarball) do tar
-            git_tree_hash(predicate, tar, SHA.SHA256_CTX, skip_empty)
+            git_tree_hash(predicate, tar, SHA.SHA256_CTX, skip_empty, skip_symlink)
         end
     else
         error("invalid tree hashing algorithm: $algorithm")
@@ -414,12 +418,14 @@ function tree_hash(
     tarball::ArgRead;
     algorithm::AbstractString = "git-sha1",
     skip_empty::Bool = false,
+    skip_symlink::Bool = false,
 )
     tree_hash(
         true_predicate,
         tarball,
         algorithm = algorithm,
         skip_empty = skip_empty,
+        skip_symlink = skip_symlink
     )
 end
 

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -207,7 +207,8 @@ function git_tree_hash(
     predicate::Function,
     tar::IO,
     ::Type{HashType},
-    skip_empty::Bool;
+    skip_empty::Bool,
+    skip_symlink::Bool = false;
     buf::Vector{UInt8} = Vector{UInt8}(undef, DEFAULT_BUFFER_SIZE),
 ) where HashType <: SHA.SHA_CTX
     # build tree with leaves for files and symlinks
@@ -229,6 +230,7 @@ function git_tree_hash(
             end
             return
         elseif hdr.type == :symlink
+            skip_symlink && return
             mode = "120000"
             hash = git_object_hash("blob", HashType) do io
                 write(io, hdr.link)


### PR DESCRIPTION
This adds a skip_symlink keyword to `tree_hash`.

This allows for the calculation of a tree hash without symlinks. This allows for the detection of
a failure condition when the operating system or file system does not support symlinks.

```julia
julia> using CodecZlib, Tar

julia> open(GzipDecompressorStream, "P4est.v2.8.1.x86_64-w64-mingw32-mpi+microsoftmpi.tar.gz") do io
           tree_hash = Tar.tree_hash(io)
       end
"89a337ea6f60a4fd58999ab73dea099e41032138"

julia> open(GzipDecompressorStream, "P4est.v2.8.1.x86_64-w64-mingw32-mpi+microsoftmpi.tar.gz") do io
           tree_hash = Tar.tree_hash(io; skip_symlink=true)
       end
"ed75b82e0dd9b53c4ac4e70376f3e6f330c72767"
```

xref: https://github.com/JuliaLang/Pkg.jl/issues/3643#issuecomment-1880017100
