### PR TITLE
Add has_symlink public API function

### DIFF
--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -426,7 +426,6 @@ end
 """
     has_symlink(tarball; [ strict = true ]) -> Bool
 
-        callback  :: Header, [ <data> ] --> Any
         tarball   :: Union{AbstractString, AbstractCmd, IO}
         strict    :: Bool
 
@@ -434,6 +433,8 @@ Checks the contents of a tar archive ("tarball") located at the path `tarball`
 for symlinks. If `tarball` is an IO handle, read the tar contents from that
 stream. If a symlink is found within the tar archive, true will be returned.
 Otherwise, false will be returned.
+
+See [`list`](@ref) regarding `strict`.
 """
 function has_symlink(
     tarball::ArgRead;
@@ -441,7 +442,7 @@ function has_symlink(
     strict::Bool = !raw,
 )
     has_symlink = false
-    list(tarball; raw, strict) do header
+    list(tarball; raw = raw, strict = strict) do header
         if header.type == :symlink
             has_symlink = true
         end

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -441,11 +441,12 @@ function has_symlink(
     raw::Bool = false,
     strict::Bool = !raw,
 )
-    has_symlink = false
+    has_symlink::Bool = false
     list(tarball; raw = raw, strict = strict) do header
         if header.type == :symlink
             has_symlink = true
         end
+        return nothing
     end
     return has_symlink
 end

--- a/src/Tar.jl
+++ b/src/Tar.jl
@@ -423,6 +423,32 @@ function tree_hash(
     )
 end
 
+"""
+    has_symlink(tarball; [ strict = true ]) -> Bool
+
+        callback  :: Header, [ <data> ] --> Any
+        tarball   :: Union{AbstractString, AbstractCmd, IO}
+        strict    :: Bool
+
+Checks the contents of a tar archive ("tarball") located at the path `tarball`
+for symlinks. If `tarball` is an IO handle, read the tar contents from that
+stream. If a symlink is found within the tar archive, true will be returned.
+Otherwise, false will be returned.
+"""
+function has_symlink(
+    tarball::ArgRead;
+    raw::Bool = false,
+    strict::Bool = !raw,
+)
+    has_symlink = false
+    list(tarball; raw, strict) do header
+        if header.type == :symlink
+            has_symlink = true
+        end
+    end
+    return has_symlink
+end
+
 ## error checking utility functions
 
 check_create_dir(dir::AbstractString) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ end
         @test isfile(skel)
         @test Tar.list(skel) == Tar.Header[]
         @test Tar.list(skel, raw=true) == Tar.Header[]
+        @test !Tar.has_symlink(skel)
         rm(skel)
     end
 
@@ -59,6 +60,7 @@ end
         rm(dir, recursive=true)
         @test Tar.list(tarball) == [Tar.Header(".", :directory, 0o755, 0, "")]
         @test Tar.list(tarball, raw=true) == [Tar.Header(".", :directory, 0o755, 0, "")]
+        @test !Tar.has_symlink(tarball)
         test_empty_hashes(tarball)
         skel = tempname()
         dir = Tar.extract(tarball, skeleton=skel)
@@ -110,6 +112,7 @@ end
                 @test !isempty(hdr.link)
             end
         end
+        @test Tar.has_symlink(tarball)
         @testset "Tar.list from IO, process, pipeline" begin
             arg_readers(tarball) do tar
                 @arg_test tar begin
@@ -1016,6 +1019,7 @@ end
         hdr = Tar.Header("LF10/LF10_B.mtx", :file, 0o100600, 367, "")
         @test open(Tar.read_header, tarball) == hdr
         @test Tar.list(tarball) == [hdr]
+        @test !Tar.has_symlink(tarball)
     end
     @testset "header errors" begin
         # generate a valid header


### PR DESCRIPTION
Implement `Tar.has_symlink` as requested by @staticfloat

```julia
julia> using Tar, CodecZlib, Downloads

julia> Downloads.download("https://github.com/JuliaBinaryWrappers/P4est_jll.jl/releases/download/P4est-v2.8.1+2/P4est.v2.8.1.x86_64-w64-mingw32-mpi+microsoftmpi.tar.gz", "P4est.v2.8.1.x86_64-w64-mingw32-mpi+microsoftmpi.tar.gz")

julia> open(GzipDecompressorStream, "P4est.v2.8.1.x86_64-w64-mingw32-mpi+microsoftmpi.tar.gz") do io
           Tar.has_symlink(io)
       end
true

julia> Downloads.download("https://github.com/JuliaBinaryWrappers/iso_codes_jll.jl/releases/download/iso_codes-v4.15.0%2B0/iso_codes.v4.15.0.any.tar.gz", "iso_codes.v4.15.0.any.tar.gz")

julia> open(GzipDecompressorStream, "iso_codes.v4.15.0.any.tar.gz") do io
           Tar.has_symlink(io)
       end
true

julia> Tar.create("empty", "foo.tar")
"foo.tar"

julia> Tar.has_symlink("foo.tar")
false
```

xref: https://github.com/JuliaLang/Pkg.jl/issues/3643#issuecomment-1880111897
