### PR TITLE
Optimize `check_checksum_field`

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -627,8 +627,8 @@ function check_version_field(buf::AbstractVector{UInt8})
 end
 
 function check_checksum_field(buf::AbstractVector{UInt8})
-    chksum = Tar.read_header_int(buf, :chksum)
-    r = Tar.index_range(:chksum)
+    chksum = read_header_int(buf, :chksum)
+    r = index_range(:chksum)
     r_first, r_last = first(r), last(r)
 
     actual = zero(UInt32)


### PR DESCRIPTION
There is no point checking this condition in every loop body when we can just split up the loop into a couple with "constant" bodies. This was decently hot in my profiling. This makes it about 7x faster and have around a 10% end to end difference in my use case.