### PR TITLE
avoid a useless copy when indexing into a buffer

### DIFF
--- a/src/extract.jl
+++ b/src/extract.jl
@@ -654,7 +654,7 @@ function read_header_str(buf::AbstractVector{UInt8}, fld::Symbol)
     r = index_range(fld)
     for i in r
         byte = buf[i]
-        byte == 0 && return String(buf[first(r):i-1])
+        byte == 0 && return String(@view buf[first(r):i-1])
     end
     return String(buf[r])
 end


### PR DESCRIPTION
And no, `String` can not take the data from the indexed buffer without copy because it needs a null terminator, it can only do this from buffers allocated with `StringVector`.