### PR TITLE
test: fix symlink blob length in git_tools.jl reference hasher

### DIFF
--- a/test/git_tools.jl
+++ b/test/git_tools.jl
@@ -39,7 +39,9 @@ Calculate the git blob hash of a given path.
 function blob_hash(::Type{HashType}, path::AbstractString) where HashType <: SHA.SHA_CTX
     ctx = HashType()
     if islink(path)
-        datalen = length(readlink(path))
+        # The git blob header is the byte length of the link target, not the number of
+        # characters; `length` is wrong for non-ASCII (multi-byte UTF-8) targets.
+        datalen = sizeof(readlink(path))
     else
         datalen = filesize(path)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,19 @@
 include("setup.jl")
 
+# Symlink targets with non-ASCII (multi-byte UTF-8) bytes: the git blob length is the
+# byte count of the target, not the character count. `Tar.tree_hash` must agree with the
+# reference `GitTools` implementation (and with `git`) for these.
+Sys.iswindows() || @testset "tree_hash: non-ASCII symlink target" begin
+    dir = mktempdir()
+    symlink("schön", joinpath(dir, "link"))  # 'ö' is two bytes in UTF-8
+    tarball = Tar.create(dir)
+    # byte-correct reference hash, cross-checked against command-line git
+    @test tree_hash(dir) == "289b9713bf8902fbd0688b0ca5584ec4cf08fdc9"
+    @test Tar.tree_hash(tarball) == tree_hash(dir)
+    rm(tarball)
+    rm(dir, recursive=true)
+end
+
 NON_STDLIB_TESTS &&
 @testset "unususal buffering" begin
     @testset "constant usage" begin


### PR DESCRIPTION
The test-only `GitTools` reference implementation in `test/git_tools.jl` (copied from Pkg.jl) computed the git blob header length for a symlink with `length(readlink(path))` — the character count rather than the byte count. For symlink targets containing non-ASCII (multi-byte UTF-8) characters this produced a hash that disagrees with canonical git and, notably, with `Tar.tree_hash` itself, which already computes the byte-correct hash.

Use `sizeof` (byte count) so the reference oracle matches `git` and `Tar.tree_hash`. Adds a regression test with a non-ASCII symlink target (reference hash cross-checked against command-line git).