### PR TITLE
test: handle FileSpec arg return value in create/rewrite tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -632,7 +632,7 @@ end
             # create(dir, tarball)
             arg_writers() do tarball, tar
                 @arg_test tar begin
-                    @test tar == Tar.create(dir, tar)
+                    @test arg_write_return(tar) == Tar.create(dir, tar)
                 end
                 @test read(tarball) == bytes
             end
@@ -656,7 +656,7 @@ end
             # create(predicate, dir, tarball)
             arg_writers() do tarball, tar
                 @arg_test tar begin
-                    @test tar == Tar.create(predicate, dir, tar)
+                    @test arg_write_return(tar) == Tar.create(predicate, dir, tar)
                 end
                 @test read(tarball) == bytes
             end
@@ -911,7 +911,7 @@ end
                 arg_writers() do new_file, new
                     @arg_test old new begin
                         new isa AbstractString && (new = Str(new))
-                        @test new == Tar.rewrite(old, new)
+                        @test arg_write_return(new) == Tar.rewrite(old, new)
                     end
                     @test ref == read(new_file)
                 end
@@ -940,7 +940,7 @@ end
                 arg_writers() do new_file, new
                     @arg_test old new begin
                         new isa AbstractString && (new = Str(new))
-                        @test new == Tar.rewrite(predicate, old, new)
+                        @test arg_write_return(new) == Tar.rewrite(predicate, old, new)
                     end
                     @test ref == read(new_file)
                 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -27,6 +27,13 @@ end
 
 tree_hash(path::AbstractString) = bytes2hex(GitTools.tree_hash(path))
 
+# `arg_write` (and the Tar functions built on it: `create`, `rewrite`, …) returns the
+# *path* for a `FileSpec` argument rather than the `FileSpec` itself. Newer ArgTools
+# exercises `FileSpec` via `arg_writers`, so normalize a writer argument to the value
+# those functions return when checking that the returned handle matches the argument.
+arg_write_return(arg) =
+    isdefined(ArgTools, :FileSpec) && arg isa ArgTools.FileSpec ? arg.path : arg
+
 function gen_file(file::String, size::Int)
     open(file, write=true) do io
         for i = 1:size; write(io, i % UInt8); end


### PR DESCRIPTION
Newer ArgTools exercises `FileSpec` arguments via `arg_writers`, and `arg_write` (so the `Tar.create`/`Tar.rewrite` functions built on it) returns the *path* for a `FileSpec` argument, not the `FileSpec` itself (documented behavior). The `@test arg == Tar.fn(..., arg)` assertions in the "API: create" and "API: rewrite" testsets assumed the return value equals the argument, which fails for the `FileSpec` case (`FileSpec(...) == "/path"`), breaking nightly CI.

Add an `arg_write_return` test helper that maps a writer argument to the value `arg_write` returns (the path for a `FileSpec`, the argument otherwise), and use it in the create and rewrite equality checks. Guarded with `isdefined(ArgTools, :FileSpec)` so it stays correct on the minimum supported ArgTools (1.1.0), which predates `FileSpec`.